### PR TITLE
Fix translation for Android

### DIFF
--- a/src/data/services/export/export_strings_android.ts
+++ b/src/data/services/export/export_strings_android.ts
@@ -21,8 +21,7 @@ const generateAndroidStringFile = (language: Language, localizedProject: Localiz
             if (localization.type === KeyType.SINGULAR) {
                 const value = (localization[language.id]?.toString() ?? "")
                   .replace(/"/g, "\\\"")
-                  .replace(/'/g, '\\\'')
-                  .replace(/%/g, '%%');
+                  .replace(/'/g, '\\\'');
                 const stringEl = xmlDoc.createElement("string");
                 stringEl.setAttribute("name", mixGroupAndKeyName(localizedGroup.name, localization.key));
                 stringEl.innerHTML = `"${replaceMarkers(value, platform)}"`;
@@ -37,7 +36,7 @@ const generateAndroidStringFile = (language: Language, localizedProject: Localiz
                     if (value !== undefined) {
                         const itemEl = xmlDoc.createElement("item");
                         itemEl.setAttribute("quantity", value[0]);
-                        itemEl.innerHTML = `"${replaceMarkers(value[1].replace(/"/g, "\\\"").replace(/'/g, '\\\'').replace(/%/g, '%%'), platform)}"`;
+                        itemEl.innerHTML = `"${replaceMarkers(value[1].replace(/"/g, "\\\"").replace(/'/g, '\\\''), platform)}"`;
                         pluralEl.appendChild(itemEl);
                     }
                 });


### PR DESCRIPTION
There was a problem on the Android translation. When I added an argument template as _%1$s_ , on the export, I had _%%1$s_ as a result, a % was added.

This PR is meant to fix the issue.